### PR TITLE
Add c++11 flags

### DIFF
--- a/src/linux/qt_linux_hmi_tester/qt_linux_hmi_tester.pro
+++ b/src/linux/qt_linux_hmi_tester/qt_linux_hmi_tester.pro
@@ -31,7 +31,7 @@ else {
 }
 
 QT += script xml network
-CONFIG += debug
+CONFIG += debug c++11
 
 TARGET = qt_linux_hmi_tester
 TEMPLATE = app


### PR DESCRIPTION
Otherwise compilation is not working on older versions of gcc (5.x)
