### PR TITLE
Use `become` to run as root, not `sudo`

### DIFF
--- a/download_compile_run.ansible.yml
+++ b/download_compile_run.ansible.yml
@@ -17,7 +17,7 @@
       - libboost-system-dev 
       - libboost-thread-dev 
       - libboost-serialization-dev
-    sudo: yes
+    become: yes
     tags:
       - packages
 


### PR DESCRIPTION
Fixes "conflicting action statements" error with Ansible 2.10.5
Closes #28